### PR TITLE
New parameter to set max-retries for api calls

### DIFF
--- a/command/wrapped_main.go
+++ b/command/wrapped_main.go
@@ -28,6 +28,7 @@ func WrappedMain() int {
 	forceDeleteFlag := set.Bool("force", false, "Start deleting without asking for confirmation")
 	profile := set.String("profile", "", "Use a specific profile from your credential file")
 	region := set.String("region", "", "The region to use. Overrides config/env settings")
+	maxRetries := set.Int("max-retries", 25, "The maximum number of times an AWS API request is being executed.")
 
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)
@@ -64,7 +65,7 @@ func WrappedMain() int {
 		region = sess.Config.Region
 	}
 
-	p := initAwsProvider(*profile, *region)
+	p := initAwsProvider(*profile, *region, *maxRetries)
 
 	ui := &cli.BasicUi{
 		Reader:      os.Stdin,
@@ -119,12 +120,13 @@ func basicHelpFunc(app string) cli.HelpFunc {
 	}
 }
 
-func initAwsProvider(profile string, region string) *terraform.ResourceProvider {
+func initAwsProvider(profile string, region string, maxRetries int) *terraform.ResourceProvider {
 	p := aws.Provider()
 
 	cfg := map[string]interface{}{
-		"region":  region,
-		"profile": profile,
+		"region":      region,
+		"profile":     profile,
+		"max_retries": maxRetries,
 	}
 
 	rc, err := config.NewRawConfig(cfg)

--- a/command/wrapped_main.go
+++ b/command/wrapped_main.go
@@ -28,7 +28,7 @@ func WrappedMain() int {
 	forceDeleteFlag := set.Bool("force", false, "Start deleting without asking for confirmation")
 	profile := set.String("profile", "", "Use a specific profile from your credential file")
 	region := set.String("region", "", "The region to use. Overrides config/env settings")
-	maxRetries := set.Int("max-retries", 25, "The maximum number of times an AWS API request is being executed.")
+	maxRetries := set.Int("max-retries", 25, "The maximum number of times an AWS API request is being executed")
 
 	log.SetFlags(0)
 	log.SetOutput(ioutil.Discard)
@@ -111,6 +111,8 @@ Options:
   --dry-run		Don't delete anything, just show what would happen
 
   --force		Start deleting without asking for confirmation
+
+  --max-retries	The maximum number of times an AWS API request is being executed
 `
 }
 


### PR DESCRIPTION
Duplicate of https://github.com/cloudetc/awsweeper/pull/35, while waiting for merging that into upstream